### PR TITLE
Dev temp

### DIFF
--- a/my_stash/views.py
+++ b/my_stash/views.py
@@ -45,4 +45,25 @@ class ItemTabelListAPIView(generics.ListAPIView):
 class ItemsetListAPIView(generics.ListAPIView):
     permission_classes = (AllowAny,)
     serializer_class = ItemsetSerializer
-    queryset = Itemset.objects.all()
+    #queryset = Itemset.objects.all()
+    def get_queryset(self):
+        return Itemset.objects.all()
+    def list(self, requaet):
+        Lis = []
+        queryset = self.get_queryset()
+        for itmset in ItemsetSerializer(queryset, many=True).data:
+            set_dic = {}
+            header_dic = {}
+            for key in itmset.keys():
+                if key == "id":
+                    set_dic[key] = itmset[key]
+                    header_dic[key] = itmset[key]
+                elif key == "owned_parts_ITEMLIST":
+                    set_dic["content_items"] = itmset[key]
+                else:
+                    header_dic[key] = itmset[key]
+            set_dic["header_info"] = header_dic
+            Lis.append(set_dic)
+        return Response(Lis)
+            
+            


### PR DESCRIPTION
[変更]　Itemset_Listコンポにおいて、APIデータを {"id": --, "header_info": --, "content_items": -- } として扱う

・上記に合わせて ItemsetAPIListview を変更

・この変更により、ネストされたv-forの動き方がある程度直感的となった
　= "id"をキーとして最初のforを回して"header_info"を処理し、"content_items"の各itemに対して次のforで処理を行う
　→ 変更の結果、辞書型オブジェを上記の形に変換するメソッドと、2回めのforの対象を検索するメソッドが消去できた
　↔ そのかわり"ITEMLIST"を感知してネストされた辞書型オブジェをMapに変換するメソッドもなくなった

　　結局Map化する必要があるので、"content_items"を検知する形で切り出すべきか？
　　↔ APIの返り値の設定をいじる以上、対応するものに一般性を求めても...という気もする
　　似たようなページを作る際に再検討しよう